### PR TITLE
Mention pkg-config package in installation instruction

### DIFF
--- a/en/installation.md
+++ b/en/installation.md
@@ -71,10 +71,10 @@ If you'd rather not install Rust via "rustup", you can also install it via other
 
 ### Debian/Ubuntu
 
-You will need to install the "libssl-dev" package:
+You will need to install the "pkg-config" and "libssl-dev" package:
 
 ```
-apt install libssl-dev
+apt install pkg-config libssl-dev
 ```
 
 Linux users who wish to use the `rawkey` or `clipboard` optional features will need to install the "libx11-dev" and "libxcb-composite0-dev" packages:

--- a/es/instalacion.md
+++ b/es/instalacion.md
@@ -71,10 +71,10 @@ Si prefieres no instalar Rust mediante "rustup", también puedes instalar a trav
 
 ### Debian/Ubuntu
 
-Vas a necesitar instalar "libssl-dev":
+Vas a necesitar instalar "pkg-config" y "libssl-dev":
 
 ```
-apt install libssl-dev
+apt install pkg-config libssl-dev
 ```
 
 Usuarios de Linux que desean usar las funcionalidades opcionales `rawkey` o `clipboard` necesitarán instalar los paquetes "libx11-dev" y "libxcb-composite0-dev":


### PR DESCRIPTION
Ubuntu distributions does not came with pkg-config by default.
OpenSSL package's documentation mention pkg-config as requirement:
https://docs.rs/openssl/0.10.24/openssl/#automatic