### PR TITLE
Build all features for cargo run

### DIFF
--- a/en/installation.md
+++ b/en/installation.md
@@ -120,7 +120,7 @@ Git will clone the main nushell repo for us. From there, we can build and run Nu
 
 ```
 > cd nushell
-nushell> cargo build && cargo run
+nushell> cargo build --all-features && cargo run --all-features
 ```
 
 You can also build and run Nu in release mode:


### PR DESCRIPTION
- For development I usually build all (or at least most) features
- Plugins are not found with standard PATH.