### PR TITLE
add table of contents and some minor improvements

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -9,8 +9,7 @@
 
 <div id="Sidenav" class="sidenav">
   <a href="javascript:void(0)" class="closebtn" onclick="closeNav()">&times;</a>
-
-  <a href="#" class="hide" data-toggle="#list_en">English</a>
+  <a id="lang_en" href="#" class="hide" data-toggle="#list_en" onclick="changeColor(this.id)">English</a>
   <ol id="list_en">
     <li><a href="{{ '/en/installation.html' | relative_url }}">Installation</a></li>
     <li><a href="{{ '/en/introduction.html' | relative_url }}">Introduction</a></li>
@@ -26,7 +25,7 @@
     <li><a href="{{ '/en/plugins.html' | relative_url }}">Plugins</a></li>
   </ol>
 
-  <a href="#" class="hide" data-toggle="#list_es">Español</a>
+  <a id="lang_es" href="#" class="hide" data-toggle="#list_es" onclick="changeColor(this.id)">Español</a>
   <ol id="list_es">
     <li><a href="{{ '/es/instalacion.html' | relative_url }}">Instalación</a></li>
     <li><a href="{{ '/es/introduccion.html' | relative_url }}">Introducción</a></li>
@@ -42,7 +41,7 @@
     <li><a href="{{ '/es/plugins.html' | relative_url }}">Plugins</a></li>
   </ol>
 
-  <a href="#" class="hide" data-toggle="#list_pt-BR">Português do Brasil</a>
+  <a id="lang_pt" href="#" class="hide" data-toggle="#list_pt-BR" onclick="changeColor(this.id)">Português do Brasil</a>
   <ol id="list_pt-BR">
     <li><a href="{{ '/pt-BR/instalacao.html' | relative_url }}">Instalação</a></li>
     <li><a href="{{ '/pt-BR/introducao.html' | relative_url }}">Introdução</a></li>
@@ -57,7 +56,7 @@
     <li><a href="{{ '/pt-BR/plugins.html' | relative_url }}">Plugins</a></li>
   </ol>
 
-  <a href="#" class="hide" data-toggle="#list_ja">日本語</a>
+  <a id="lang_ja" href="#" class="hide" data-toggle="#list_ja" onclick="changeColor(this.id)">日本語</a>
   <ol id="list_ja">
     <li><a href="{{ '/ja/installation.html' | relative_url }}">インストール</a></li>
     <li><a href="{{ '/ja/introduction.html' | relative_url }}">はじめに</a></li>
@@ -71,6 +70,8 @@
     <li><a href="{{ '/ja/escaping.html' | relative_url }}">コマンドのエスケープ</a></li>
     <li><a href="{{ '/ja/plugins.html' | relative_url }}">プラグイン</a></li>
   </ol>
+  <br>
+  Click to expand language-specific table of contents
 </div>
 
 <script>
@@ -82,6 +83,13 @@
         function closeNav() {
           document.getElementById("Sidenav").style.width = "0";
           document.getElementById("main").style.marginLeft = "0";
+        }
+        function changeColor(elementID) {
+          if (document.getElementById(elementID).style.color == "rgb(136, 136, 136)") {
+            document.getElementById(elementID).style.color = "#51cd28"
+          } else {
+            document.getElementById(elementID).style.color = "#888888"
+          }
         }
 </script>
 <script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -38,12 +38,12 @@
           <div class="lang_sel">
               <table>
                   <tr>
-                    <a href="{{ '/en/installation.html' | relative_url }}">English</a>
-                    <a href="{{ '/es/instalacion.html' | relative_url }}">Español</a>
+                    <a href="{{ '/en/table_of_contents.html' | relative_url }}">English</a>
+                    <a href="{{ '/es/indice.html' | relative_url }}">Español</a>
                   </tr>
                   <tr>
-                    <a href="{{ '/pt-BR/instalacao.html' | relative_url }}">Português do Brasil</a>
-                    <a href="{{ '/ja/installation.html' | relative_url }}">日本語</a>
+                    <a href="{{ '/pt-BR/indice.html' | relative_url }}">Português do Brasil</a>
+                    <a href="{{ '/ja/table_of_contents.html' | relative_url }}">日本語</a>
                   </tr>
                 </table>
           </div>

--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -449,11 +449,12 @@ section {
   overflow-x: hidden;
   padding-top: 60px;
   transition: 0.5s;
+  color: #888888;
   a {
     padding: 8px 8px 8px 5px;
     text-decoration: none;
     font-size: 25px;
-    color: #888888;
+    color: $green-bright;
     display: block;
     transition: 0.3s;
     font-size: 18px;

--- a/books.md
+++ b/books.md
@@ -7,6 +7,6 @@ layout: books
 
 In the [contributers book](https://www.nushell.sh/contributor-book/) you can find further information. It attempts to cover the basics of how Nu works internally, to get a solid understanding. You will learn how data is treated, what kind of data types Nu supports and how you can write plugins for it.
 
-# [Cookbook](https://github.com/nushell/cookbook)
+# [Cookbook](https://www.nushell.sh/cookbook/)
 
-[Nu Cookbook](https://github.com/nushell/cookbook) is a collection of examples to help you get the most out of using Nushell. It offers multiple ways of expressing the same pipelines so you can become familiar with all the commands.
+[Nu Cookbook](https://www.nushell.sh/cookbook/) is a collection of examples to help you get the most out of using Nushell. It offers multiple ways of expressing the same pipelines so you can become familiar with all the commands.

--- a/en/installation.md
+++ b/en/installation.md
@@ -1,9 +1,9 @@
 ---
 layout: content
 title: Installing Nu
-prev: START
+prev: Table of Contents
 next: Introduction
-link_prev: /
+link_prev: /en/table_of_contents.html
 link_next: /en/introduction.html
 ---
 

--- a/en/table_of_contents.md
+++ b/en/table_of_contents.md
@@ -1,0 +1,21 @@
+---
+layout: content
+title: Table of Contents
+prev: Languages
+next: Installation
+link_prev: /
+link_next: /en/installation.html
+---
+
+* [Installation](installation.md) - Installing nushell
+* [Introduction](introduction.md) - Getting started
+* [Moving around](moving_around.md) - Moving around in nushell
+* [Types of data](types_of_data.md) - Types of data in nushell
+* [Loading data](loading_data.md) - Loading data and using it
+* [Working with tables](working_with_tables.md) - Working with nushell tables
+* [Pipeline](pipeline.md) - How the pipeline works
+* [Configuration](configuration.md) - How to configure nushell
+* [Metadata](metadata.md) - An explanation of nushell's metadata system
+* [Shells](shells_in_shells.md) - Working with multiple locations
+* [Escaping commands](escaping.md) - Escaping to native commands of the same name 
+* [Plugins](plugins.md) - Enhancing nushell with more features using plugins

--- a/es/indice.md
+++ b/es/indice.md
@@ -1,0 +1,21 @@
+---
+layout: content
+title: Índice
+prev: Idiomas
+next: Instalación
+link_prev: /
+link_next: /es/instalacion.html
+---
+
+* [Instalación](instalacion.md) - Instalando nushell
+* [Introducción](introduccion.md) - Empezando
+* [Explorando](explorando.md) - Explorando en nushell
+* [Tipos de datos](tipos_de_datos.md) - Tipos de datos en nushell
+* [Cargando datos](cargando_datos.md) - Cargando datos y usándola
+* [Trabajando con tablas](trabajando_con_tablas.md) - Trabajando con tablas nushell
+* [Pipeline](pipeline.md) - Cómo funciona el pipeline
+* [Configuración](configuracion.md) - Cómo configurar nushell
+* [Metadatos](metadatos.md) - Una explicación del sistema de metadatos en nushell
+* [Shells](shells_en_shells.md) - Trabajando con múltiples ubicaciones
+* [Escapando commandos](escapando.md) - Escapando a comandos nativos de mismo nombre
+* [Plugins](plugins.md) - Mejorando nushell con más funcionalidades usando complementos

--- a/es/instalacion.md
+++ b/es/instalacion.md
@@ -1,9 +1,9 @@
 ---
 layout: content
 title: Instalando Nu
-prev: START
+prev: Índice
 next: Introduccion
-link_prev: /
+link_prev: /es/indice.html
 link_next: /es/introduccion.html
 ---
 

--- a/ja/installation.md
+++ b/ja/installation.md
@@ -3,7 +3,7 @@ layout: content
 title: Nuのインストール
 prev: 開始
 next: はじめに
-link_prev: /
+link_prev: /ja/table_of_contents.html
 link_next: /ja/introduction.html
 ---
 

--- a/ja/table_of_contents.md
+++ b/ja/table_of_contents.md
@@ -1,0 +1,20 @@
+---
+layout: content
+title: 目次
+prev: 言語
+next: インストール
+link_prev: /
+link_next: /ja/installation.html
+---
+
+* [インストール](installation.md) - nushellのインストール
+* [はじめに](introduction.md) - nushellをはじめよう
+* [ファイルシステムの操作](moving_around.md) - nushellからファイルシステムを扱おう
+* [データ型](types_of_data.md) - nushellのデータ型
+* [データの読み込み](loading_data.md) - データの読み込みとその利用方法
+* [テーブル](working_with_tables.md) - テーブルを利用してみよう
+* [パイプライン](pipeline.md) - パイプラインの仕組み
+* [メタデータ](metadata.md) - nushellにおけるメタデータについて
+* [シェル](shells_in_shells.md) - 複数の場所で作業しよう
+* [コマンドのエスケープ](escaping.md) - Nuコマンドと同じ名前のコマンドを実行するには
+* [プラグイン](plugins.md) - プラグインを利用してnushellを拡張する

--- a/pt-BR/indice.md
+++ b/pt-BR/indice.md
@@ -1,0 +1,20 @@
+---
+layout: content
+title: Índice
+prev: Línguas
+next: Instalação
+link_prev: /
+link_next: /pt-BR/instalacao.html
+---
+
+* [Instalação](instalacao.md) - Instalando o nushell
+* [Introdução](introducao.md) - Começando a usar o nushell
+* [Explorando](explorando.md) - Explorando o nushell
+* [Tipos de dados](tipos_de_dados.md) - Tipos de dados no nushell
+* [Carregando dados](carregando_dados.md) - Carregando e usando dados
+* [Trabalhando com tabelas](trabalhando_com_tabelas.md) - Trabalhando com as tabelas do nushell
+* [Pipeline](pipeline.md) - Como o pipeline funciona
+* [Metadados](metadados.md) - Uma explicação sobre o sistema de metadados do nushell
+* [Shells](shells_em_shells.md) - Trabalhando com múltiplos locais
+* [Escapando comandos](escapando.md) - Escapando para comandos nativos com o mesmo nome
+* [Plugins](plugins.md) - Melhorando o nushell com mais funcionalidades usando plugins

--- a/pt-BR/instalacao.md
+++ b/pt-BR/instalacao.md
@@ -1,9 +1,9 @@
 ---
 layout: content
 title: Instalando Nu
-prev: START
+prev: Índice
 next: Introdução
-link_prev: /
+link_prev: /pt-BR/indice.html
 link_next: /pt-BR/introducao.html
 ---
 


### PR DESCRIPTION
PR updates a couple of things:
- table of contents for every language after selecting the language ([#1175](https://github.com/nushell/nushell/issues/1175))
- color for languages in sidebar changed to the standard link color
- Description of how to get the table of contents in the sidebar
- Link to cookbook
