### PR TITLE
Add CONTRIBUTING.md with local Docker setup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Contributing
+
+If you want to contribute to nushell itself, see [nushell/nushell/CONTRIBUTING.md](https://github.com/nushell/nushell/blob/master/CONTRIBUTING.md) and the [contributor-book](https://github.com/nushell/contributor-book).
+
+This book is based on Jekyll, which requires Ruby.
+
+## Running locally with Docker
+
+To avoid installing dependencies locally, run with Docker:
+```
+docker-compose up
+```
+
+Runing that command will first download the `jekyll/jekyll` Docker image. That will install dependencies, which can take a while. Once its done, open http://localhost:8080/
+
+Changes in files will then show up after a reload and some delay (can be ~10 seconds).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,15 @@ If you want to contribute to nushell itself, see [nushell/nushell/CONTRIBUTING.m
 
 This book is based on Jekyll, which requires Ruby.
 
+## Running locally with Bundler
+
+To run this locally (without Docker, see below), you need the [dependencies as specified by Jekyll](https://jekyllrb.com/docs/installation/), then run these commands:
+```shell
+bundle install
+bundle exec jekyll serve
+```
+Then open http://localhost:4000/
+
 ## Running locally with Docker
 
 To avoid installing dependencies locally, run with Docker:
@@ -11,6 +20,6 @@ To avoid installing dependencies locally, run with Docker:
 docker-compose up
 ```
 
-Runing that command will first download the `jekyll/jekyll` Docker image. That will install dependencies, which can take a while. Once its done, open http://localhost:8080/
+Runing that command will first download the `jekyll/jekyll` Docker image. That will install dependencies, which can take a while. Once its done, open http://localhost:4000/
 
 Changes in files will then show up after a reload and some delay (can be ~10 seconds).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '2.4'
+
+services:
+  jekyll:
+    image: jekyll/jekyll:3.8
+    command: jekyll serve
+    volumes:
+      - .:/srv/jekyll
+    ports:
+      - '8080:4000'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,4 +7,4 @@ services:
     volumes:
       - .:/srv/jekyll
     ports:
-      - '8080:4000'
+      - '4000:4000'


### PR DESCRIPTION
Getting jekyll running locally requires a working Ruby env, so avoid that by adding a docker-compose.yml that will run `jekyll serve` locally.

Fixes #69