### PR TITLE
configuration: add startup variable

### DIFF
--- a/en/configuration.md
+++ b/en/configuration.md
@@ -13,6 +13,7 @@ Nu has a small, but growing, number of internal variables you can set to change 
 | ------------- | ------------- | ----- |
 | path | table of strings | PATH to use to find binaries |
 | env | row | the environment variables to pass to external commands |
+| startup | table of strings | commands like `alias`es to run on when nushell starts |
 | ctrlc_exit | boolean | whether or not to exit Nu after multiple ctrl-c presses |
 | table_mode | "light" or other | enable lightweight or normal tables |
 | edit_mode | "vi" or "emacs" | changes line editing to "vi" or "emacs" mode |

--- a/en/configuration.md
+++ b/en/configuration.md
@@ -13,7 +13,7 @@ Nu has a small, but growing, number of internal variables you can set to change 
 | ------------- | ------------- | ----- |
 | path | table of strings | PATH to use to find binaries |
 | env | row | the environment variables to pass to external commands |
-| startup | table of strings | commands like `alias`es to run on when nushell starts |
+| startup | table of strings | commands, like `alias`es, to run on when nushell starts |
 | ctrlc_exit | boolean | whether or not to exit Nu after multiple ctrl-c presses |
 | table_mode | "light" or other | enable lightweight or normal tables |
 | edit_mode | "vi" or "emacs" | changes line editing to "vi" or "emacs" mode |


### PR DESCRIPTION
I'm guessing the type and description based on the 0.13.0 release blog post:  https://www.nushell.sh/blog/2020/04/21/nushell_0_13_0.html#startup-commands-jonathandturner

I still haven't figured out what "table of strings" actually is. The types documentation doesn't mention them: https://www.nushell.sh/book/en/types_of_data.html

This has a good chance to be correct anyway, even if not particularly helpful without an example - see #72 for my struggle with examples for `startup`.