### PR TITLE
List command to display the Starship prompt

### DIFF
--- a/en/configuration.md
+++ b/en/configuration.md
@@ -138,10 +138,24 @@ With this, you should be able to `chsh` and set Nu to be your login shell. After
 
 ## Prompt configuration
 
-Currently, prompt configuration is handled by installing Nu with the [starship](https://github.com/starship/starship) prompt support.
+Currently, prompt configuration is handled by installing Nu with the [starship](https://github.com/starship/starship) prompt support. The starship prompt support is available by default.
+
+From v0.16, displaying the starship prompt is now a configuration option. The prompt is disabled by default. To change config options one must be in the nu shell.
+
+To enable the starship prompt, enter the following command:
 
 ```
-nushell on 📙 master [$] is 📦 v0.5.1 via 🦀 v1.40.0-nightly
+config set use_starship $true
+```
+
+To disable the starship prompt, enter the following command:
+
+```
+config set use_starship $false
+```
+
+```
+nushell on 📙 master [$] is 📦 v0.16.1 via 🦀 v1.45.0-nightly
 ❯
 ```
 

--- a/en/configuration.md
+++ b/en/configuration.md
@@ -138,9 +138,7 @@ With this, you should be able to `chsh` and set Nu to be your login shell. After
 
 ## Prompt configuration
 
-Currently, prompt configuration is handled by installing Nu with the [starship](https://github.com/starship/starship) prompt support. The starship prompt support is available by default.
-
-Starting with v0.16, displaying the starship prompt is now a configuration option. The prompt is disabled by default, but can be enabled using the `use_starship` config setting
+Currently, prompt configuration is handled by installing Nu with the [starship](https://github.com/starship/starship) feature. The starship prompt can then be used via the `use_starship` config setting.
 
 To enable the starship prompt, enter the following command (in 0.16.1 and later):
 

--- a/en/configuration.md
+++ b/en/configuration.md
@@ -140,15 +140,15 @@ With this, you should be able to `chsh` and set Nu to be your login shell. After
 
 Currently, prompt configuration is handled by installing Nu with the [starship](https://github.com/starship/starship) prompt support. The starship prompt support is available by default.
 
-From v0.16, displaying the starship prompt is now a configuration option. The prompt is disabled by default. To change config options one must be in the nu shell.
+Starting with v0.16, displaying the starship prompt is now a configuration option. The prompt is disabled by default, but can be enabled using the `use_starship` config setting
 
-To enable the starship prompt, enter the following command:
+To enable the starship prompt, enter the following command (in 0.16.1 and later):
 
 ```
 config set use_starship $true
 ```
 
-To disable the starship prompt, enter the following command:
+To disable the starship prompt, enter the following command (in 0.16.1 and later):
 
 ```
 config set use_starship $false


### PR DESCRIPTION
Add commands to enable/disable the starship prompt using the new use_starship config option (https://www.nushell.sh/blog/2020/06/30/nushell_0_16_0.html).